### PR TITLE
Pare sponsor offerings to 4 tiers and raise pricing ~1.75x

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,12 @@
 # Polar.sh Integration
 POLAR_ACCESS_TOKEN=your_polar_access_token_here
-POLAR_30SEC_PRODUCT_ID=your_30sec_product_id_here
+# The Distiller's Cut — single 60s host-read episode
 POLAR_60SEC_PRODUCT_ID=your_60sec_product_id_here
-POLAR_BOTTLEDROP_PRODUCT_ID=your_bottledrop_product_id_here
+# The Crate — monthly package
 POLAR_CRATE_PRODUCT_ID=your_crate_product_id_here
+# The Full Barrel — flagship monthly package
 POLAR_FULLBARREL_PRODUCT_ID=your_fullbarrel_product_id_here
-POLAR_LABEL_PRODUCT_ID=your_label_product_id_here
+# The Single Barrel is a bespoke tier handled via /contact (no Polar product)
 POLAR_SUCCESS_URL=https://whiskey.fm/sponsor/success
 
 # Optional: Set to "sandbox" for testing, "production" for live (defaults to production)

--- a/README.md
+++ b/README.md
@@ -177,8 +177,8 @@ This site uses Polar.sh for sponsor checkout. To set it up:
 1. **Get your Polar credentials:**
    - Log in to your [Polar dashboard](https://polar.sh)
    - Go to Settings → API to get your access token
-   - Create two products for your sponsorship packages (30-second and 60-second
-     ads)
+   - Create one product per paid sponsorship package (The Distiller's Cut, The
+     Crate, and The Full Barrel)
    - Note the product IDs from each product's page
 
 2. **Configure environment variables:** Create a `.env` file in the root
@@ -186,12 +186,9 @@ This site uses Polar.sh for sponsor checkout. To set it up:
 
    ```env
    POLAR_ACCESS_TOKEN=your_polar_access_token_here
-   POLAR_30SEC_PRODUCT_ID=your_30sec_product_id_here
    POLAR_60SEC_PRODUCT_ID=your_60sec_product_id_here
-   POLAR_BOTTLEDROP_PRODUCT_ID=your_bottledrop_product_id_here
    POLAR_CRATE_PRODUCT_ID=your_crate_product_id_here
    POLAR_FULLBARREL_PRODUCT_ID=your_fullbarrel_product_id_here
-   POLAR_LABEL_PRODUCT_ID=your_label_product_id_here
    POLAR_SUCCESS_URL=https://whiskey.fm/sponsor/success
    ```
 

--- a/src/components/AdPackageCard.astro
+++ b/src/components/AdPackageCard.astro
@@ -3,11 +3,21 @@ export interface Props {
   bullets: Array<string>;
   heading: string;
   price: string;
-  productId: string;
+  productId?: string;
   period?: string;
+  ctaLabel?: string;
+  ctaHref?: string;
 }
 
-const { bullets, heading, price, productId, period = 'per episode' } = Astro.props;
+const {
+  bullets,
+  heading,
+  price,
+  productId,
+  period = 'per episode',
+  ctaLabel = 'Become a sponsor',
+  ctaHref = `/api/checkout?products=${productId}`
+} = Astro.props;
 ---
 
 <div
@@ -34,22 +44,26 @@ const { bullets, heading, price, productId, period = 'per episode' } = Astro.pro
       class="text-light-text-heading mt-8 mb-12 flex-1 content-end px-5 text-4xl font-bold tabular-nums dark:text-white"
     >
       {price}
-      <span
-        class="text-light-text-body dark:text-dark-text-body text-3xl font-light"
-      >
-        /
-      </span>
-      <span class="text-light-text-body dark:text-dark-text-body text-lg">
-        {period}
-      </span>
+      {
+        period && (
+          <>
+            <span class="text-light-text-body dark:text-dark-text-body text-3xl font-light">
+              /
+            </span>
+            <span class="text-light-text-body dark:text-dark-text-body text-lg">
+              {period}
+            </span>
+          </>
+        )
+      }
     </h3>
 
     <div class="flex w-full">
-      <a class="btn mb-8 w-full justify-center" href={`/api/checkout?products=${productId}`}>
+      <a class="btn mb-8 w-full justify-center" href={ctaHref}>
         <span
           class="text-light-text-heading rounded-full px-8 py-3 text-center text-sm dark:text-white"
         >
-          Become a sponsor
+          {ctaLabel}
         </span>
       </a>
     </div>

--- a/src/pages/sponsor.astro
+++ b/src/pages/sponsor.astro
@@ -219,43 +219,22 @@ const currentYear = new Date().getFullYear();
     <div class="grid grid-cols-1 gap-6 lg:grid-cols-2">
       <AdPackageCard
         bullets={[
-          'Have a bottle of whiskey or software product reviewed',
-          'Honest, positive mention during Whiskey and/or Whatnot segments'
+          'A baked-in, high-trust host-read ad',
+          '60-seconds, pre- or mid-roll',
+          'Logo & link in the show notes and on the site'
         ]}
-        heading="The Drop"
-        price="$250"
-        productId=`${import.meta.env.POLAR_BOTTLEDROP_PRODUCT_ID || 'YOUR_BOTTLEDROP_PRODUCT_ID'}`
-      />
-      <AdPackageCard
-        bullets={[
-          'Ad on our website or in the show notes',
-          'Placed prominently on main page and show notes',
-          'Consistent exposure outside of the audio feed'
-        ]}
-        heading="The Label"
-        price="$250"
-        productId=`${import.meta.env.POLAR_LABEL_PRODUCT_ID || 'YOUR_LABEL_PRODUCT_ID'}`
-      />
-      <AdPackageCard
-        bullets={['A baked in, high-trust host read pre-roll ad', '30-seconds']}
         heading="The Distiller's Cut"
-        price="$500"
-        productId=`${import.meta.env.POLAR_30SEC_PRODUCT_ID || 'YOUR_30SEC_PRODUCT_ID'}`
-      />
-      <AdPackageCard
-        bullets={['A baked in, high-trust host read pre-roll ad', '60-seconds']}
-        heading="The Spirit Maker's Cut"
-        price="$1k"
+        price="$1,750"
         productId=`${import.meta.env.POLAR_60SEC_PRODUCT_ID || 'YOUR_60SEC_PRODUCT_ID'}`
       />
       <AdPackageCard
         bullets={[
-          '4x 30-second host-read ads',
+          '4x 60-second host-read ads',
           '4x website & show notes placements',
-          'Perfect for consistent monthly presence'
+          'Perfect for a consistent monthly presence'
         ]}
         heading="The Crate"
-        price="$2.4k"
+        price="$4,200"
         period="per month"
         productId=`${import.meta.env.POLAR_CRATE_PRODUCT_ID || 'YOUR_CRATE_PRODUCT_ID'}`
       />
@@ -268,9 +247,22 @@ const currentYear = new Date().getFullYear();
           'Social media mentions for each episode'
         ]}
         heading="The Full Barrel"
-        price="$4k"
+        price="$7,000"
         period="per month"
         productId=`${import.meta.env.POLAR_FULLBARREL_PRODUCT_ID || 'YOUR_FULLBARREL_PRODUCT_ID'}`
+      />
+      <AdPackageCard
+        bullets={[
+          'A co-branded single-barrel whiskey pick, selected on-air',
+          'Custom bottles for your team, your customers, or a listener giveaway',
+          'Audio, video & social rolled around the selection',
+          'Our most unique, most memorable sponsorship'
+        ]}
+        heading="The Single Barrel"
+        price="Custom"
+        period=""
+        ctaLabel="Let's talk"
+        ctaHref="/contact"
       />
     </div>
 


### PR DESCRIPTION
## What

Trims the sponsor page from six packages down to a clean four-tier ladder and raises pricing across the board (~1.75x). Adds a new bespoke "Single Barrel" tier to stand out from typical podcast sponsorship menus.

| Tier | Offering | Price |
|---|---|---|
| Entry (single ep) | **The Distiller's Cut** — 60s baked-in host-read + show-notes/site placement | **$1,750/episode** |
| Workhorse (monthly) | **The Crate** — 4× 60s host-reads + 4× placements | **$4,200/mo** |
| Flagship (monthly) | **The Full Barrel** — Crate + "Presented By" titles + per-episode social | **$7,000/mo** |
| Bespoke | **The Single Barrel** — co-branded on-air single-barrel whiskey pick, custom bottles, multi-channel | **Custom → "Let's talk"** |

- The old **Label** folds into the Distiller's Cut as a bundled placement.
- **The Drop** (product review) and the standalone **30s read** are retired.
- The bespoke tier routes to `/contact` for a custom quote rather than Polar checkout.

## Why

Too many overlapping options and a desire to raise rates. Based on 2026 benchmark research: dev/tech podcasts command premium host-read CPMs ($45–65), peers (Changelog $3k/wk, Practical AI $1.2k/ep) sell flat-rate per-episode/monthly, and almost nobody productizes a bespoke/experiential offering — hence the whiskey-native Single Barrel as a differentiator.

## Changes

- `src/pages/sponsor.astro` — 6 → 4 cards, new pricing, bespoke tier
- `src/components/AdPackageCard.astro` — optional `ctaLabel`/`ctaHref` and suppressible `period`; `productId` now optional (backward-compatible)
- `.env.example` / `README.md` — drop unused `POLAR_30SEC`/`BOTTLEDROP`/`LABEL` product IDs

## Notes for reviewers

- **Pricing vs CPM:** at 3–10K downloads/ep, $1,750 for a 60s read sits above the $45–65 tech CPM benchmark — defensible on the multi-channel + evergreen story, but it's a value/scarcity play, not CPM.
- Volume discounts (10/15/20% for 3/6/12-month commits) are common among peers but not added here — easy follow-up if wanted.
- `astro check` passes (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated sponsorship integration documentation to reflect revised tier setup and configuration instructions.

* **New Features**
  * Refreshed sponsorship tier offerings with updated pricing structure and a new tier option.
  * Improved sponsorship package cards with enhanced flexibility for customizing call-to-action elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->