### PR TITLE
fix(standard.site): publish episode docs with publication AT-URI

### DIFF
--- a/scripts/publish-episodes.ts
+++ b/scripts/publish-episodes.ts
@@ -22,6 +22,7 @@ import { array, number, object, optional, parse, string } from 'valibot';
 
 import {
   StandardSitePublisher,
+  getPublicationAtUri,
   type PublishDocumentInput
 } from '@bryanguffey/astro-standard-site';
 
@@ -88,6 +89,16 @@ async function main() {
   await publisher.login();
   console.log(`✅ Logged in as ${publisher.getDid()}`);
 
+  // A document is tied to its publication via the `site` field pointing at the
+  // publication's AT-URI (not the https site URL). Bluesky resolves
+  // document.site -> publication record to attach the publication ref that
+  // gives shared links their "publication" badge. The page URL is reconstructed
+  // from the publication record's `url` + the document `path`.
+  const publicationUri = getPublicationAtUri(
+    publisher.getDid(),
+    publicationRkey
+  );
+
   // Get existing documents to avoid duplicates
   const existingPaths = new Set<string>();
   let cursor: string | undefined;
@@ -133,7 +144,7 @@ async function main() {
       : description;
 
     const input: PublishDocumentInput = {
-      site: siteUrl,
+      site: publicationUri,
       path,
       title: episode.title,
       description,

--- a/scripts/publish-episodes.ts
+++ b/scripts/publish-episodes.ts
@@ -8,7 +8,6 @@
  * Required environment variables:
  *   ATPROTO_HANDLE - Your Bluesky handle (e.g., your-handle.bsky.social)
  *   ATPROTO_APP_PASSWORD - An app password from bsky.app/settings/app-passwords
- *   STANDARD_SITE_URL - Your podcast site URL (e.g., https://whiskey.fm)
  *   STANDARD_SITE_PUBLICATION_RKEY - The publication record key
  *
  * Usage:
@@ -56,13 +55,12 @@ const FeedSchema = object({
 async function main() {
   const identifier = process.env.ATPROTO_HANDLE;
   const password = process.env.ATPROTO_APP_PASSWORD;
-  const siteUrl = process.env.STANDARD_SITE_URL;
   const publicationRkey = process.env.STANDARD_SITE_PUBLICATION_RKEY;
 
-  if (!identifier || !password || !siteUrl || !publicationRkey) {
+  if (!identifier || !password || !publicationRkey) {
     console.log(
       'ℹ️  standard.site/ATProto not configured — skipping episode publishing.\n' +
-        '   To enable, set: ATPROTO_HANDLE, ATPROTO_APP_PASSWORD, STANDARD_SITE_URL, STANDARD_SITE_PUBLICATION_RKEY'
+        '   To enable, set: ATPROTO_HANDLE, ATPROTO_APP_PASSWORD, STANDARD_SITE_PUBLICATION_RKEY'
     );
     return;
   }


### PR DESCRIPTION
Bluesky shows the publication-promoted card by resolving a `site.standard.document` record's `site` field → the publication record. Episodes were published with `site: "https://whiskey.fm"` (a bare URL), so the publication ref was never attached and shared links showed no publication status.

This makes `publish-episodes.ts` write the **publication AT-URI** as `site` so newly-published episodes carry the publication association (the page URL still reconstructs as `publication.url` + `path`).

The existing 247 records were already migrated in place out-of-band and verified via cardyb `/v1/extract` (episode URLs now return both `site.standard.document` and `site.standard.publication` refs). This PR only prevents **future** episodes from regressing.